### PR TITLE
Fix markdown-it-emoji import

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -19,7 +19,7 @@ import attrs from 'markdown-it-attrs';
 // @ts-ignore
 import lazyHeaders from 'markdown-it-lazy-headers';
 // @ts-ignore
-import emoji from 'markdown-it-emoji';
+import {light as emoji} from 'markdown-it-emoji';
 // @ts-ignore
 import expandTabs from 'markdown-it-expand-tabs';
 // @ts-ignore


### PR DESCRIPTION
## Summary
- adjust parser to import the `light` export from `markdown-it-emoji`

## Testing
- `npm test` *(fails: TS errors)*
- `node -e "const parse=require('./lib/src/parser/parser.js').default; console.log('result tokens', parse('# Hello').length);"`

------
https://chatgpt.com/codex/tasks/task_e_68729c496dd4832abc9e0c31505448ba