### PR TITLE
Resolve emoji plugin import conflict

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -18,7 +18,7 @@ import Token from 'markdown-it/lib/token';
 // Use require for plugins to ensure proper loading since some don't have proper ES module exports
 const attrs = require('markdown-it-attrs');
 const lazyHeaders = require('markdown-it-lazy-headers');
-const emoji = require('markdown-it-emoji');
+const { light: emoji } = require('markdown-it-emoji');
 const expandTabs = require('markdown-it-expand-tabs');
 const video = require('markdown-it-video');
 


### PR DESCRIPTION
## Summary
- address merge conflict from PR #2
- use `light` export from `markdown-it-emoji` with CommonJS `require`

## Testing
- `npm install --ignore-scripts`
- `npm test` *(fails: TS errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_687349881cf4832aa50817dcb2300962