### PR TITLE
Fix Docker build by ignoring prepare scripts

### DIFF
--- a/DOCKER_CLEAN_SOLUTION.md
+++ b/DOCKER_CLEAN_SOLUTION.md
@@ -29,7 +29,7 @@ const attrs = require('markdown-it-attrs');
 
 ### 4. **Dockerfile avec contournements**
 **Problème** : `--ignore-scripts` et compilation permissive
-**Solution** : Build standard avec `npm run compile`
+**Solution** : Utiliser `npm ci --ignore-scripts` suivi de `npm run compile`
 
 ## 🔧 **Changements techniques**
 
@@ -46,7 +46,7 @@ RUN npm install --ignore-scripts
 ### **Après (solution propre)**
 ```dockerfile
 # Build standard sans contournements
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN npm run compile
 ```
 
@@ -68,7 +68,7 @@ RUN npm run compile
 - ✅ Compatibilité gts maintenue
 
 ### 4. **`Dockerfile`**
-- ✅ Suppression des flags `--ignore-scripts`
+- ✅ Installation avec `npm ci --ignore-scripts`
 - ✅ Build TypeScript standard
 - ✅ Gestion d'erreurs appropriée
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 COPY package.json ./
 COPY yarn.lock* package-lock.json* ./
 
-# Install dependencies with proper build scripts
-RUN npm ci
+# Install dependencies without running lifecycle scripts
+RUN npm ci --ignore-scripts
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- avoid npm prepare step during Docker build
- document the change in DOCKER_CLEAN_SOLUTION

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68739ba0e7d8832a8a2a870089d887c8