### PR TITLE
Fix Docker install step to skip lifecycle scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ WORKDIR /app
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/package-lock.json* ./
 
-# Install only production dependencies
-RUN npm ci --omit=dev && npm cache clean --force
+# Install only production dependencies without running lifecycle scripts
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 
 # Copy compiled code from builder stage
 COPY --from=builder /app/lib ./lib


### PR DESCRIPTION
## Summary
- prevent npm from running lifecycle scripts during production install

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873b6f3a3c4832a97559a9ce7931e44