### PR TITLE
Fix Docker install step for md2slides

### DIFF
--- a/md2slides/Dockerfile
+++ b/md2slides/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install --omit=dev
+# Install production dependencies only, skipping lifecycle scripts
+RUN npm install --omit=dev --ignore-scripts
 COPY md2slides/server.js ./md2slides/server.js
 EXPOSE 3000
 CMD ["node", "md2slides/server.js"]


### PR DESCRIPTION
## Summary
- skip npm lifecycle scripts when installing production deps in md2slides Dockerfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a47e33d40832a8e46a898714c0dbb