### PR TITLE
Fix OAuth setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ curl -sSL https://raw.githubusercontent.com/pmboutet/md2googleslides/main/script
 1. Créez un projet sur [Google Cloud Console](https://console.developers.google.com)
 2. Activez l'API Google Slides
 3. Créez des credentials OAuth 2.0 pour "Application de bureau"
+   - Ajoutez `http://localhost` aux **URI de redirection autorisées**
 4. Téléchargez le fichier JSON et sauvegardez-le comme `~/.md2googleslides/client_id.json`
+5. Lors de la première utilisation, ouvrez l'URL fournie et copiez le paramètre
+   `code` affiché dans la barre d'adresse puis collez‑le lorsque le programme
+   le demande
 
 ```bash
 mkdir -p ~/.md2googleslides

--- a/bin/md2gslides.js
+++ b/bin/md2gslides.js
@@ -121,6 +121,8 @@ function prompt(url) {
     console.log('Authorize this app in your browser.');
     console.log('\n\uD83D\uDC49 Open this URL to authorize the app:\n' + url + '\n');
     opener(url);
+    console.log('\nIf the browser shows a connection error, copy the "code" parameter');
+    console.log('from the address bar and paste it below.');
   }
   return new Promise((resolve, reject) => {
     const rl = readline.createInterface({

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ function generateAuthUrl(user) {
         const oAuth2Client = new OAuth2Client(
             creds.client_id,
             creds.client_secret,
-            'urn:ietf:wg:oauth:2.0:oob'
+            'http://localhost'
         );
         return oAuth2Client.generateAuthUrl({
             access_type: 'offline',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -55,7 +55,9 @@ interface CredentialsDb {
  *   @returns {Promise.<String>} Promise yielding the authorization code
  */
 export default class UserAuthorizer {
-  private redirectUrl = 'urn:ietf:wg:oauth:2.0:oob';
+  // Google deprecated the `oob` redirect URI. Use loopback and ask the user to
+  // copy the code from the failing browser page.
+  private redirectUrl = 'http://localhost';
   private db: LowSync<CredentialsDb>;
   private clientId: string;
   private clientSecret: string;


### PR DESCRIPTION
## Summary
- update OAuth flow to use loopback redirect URI
- hint user to copy the code from the browser
- document new OAuth redirect instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a80ca38fc832a95a3b3b2091a54ee