### PR TITLE
Update HTTP server docs with OAuth info

### DIFF
--- a/HTTP_SERVER.md
+++ b/HTTP_SERVER.md
@@ -51,6 +51,14 @@ Content-Type: multipart/form-data
 - `GOOGLE_CREDENTIALS_JSON` - Google service account credentials
 - `NODE_ENV` - Environment mode (production/development)
 
+## OAuth Credentials
+
+The HTTP service expects credentials from a Google **Web application** OAuth
+client. When creating the OAuth client in the Google Cloud Console, add
+`http://localhost` to the list of authorized redirect URIs. Download the JSON
+file and place it as `client_id.json` under `~/.md2googleslides/` so the server
+can prompt for user authorization when needed.
+
 ## Docker Usage
 
 ### Build and Run


### PR DESCRIPTION
## Summary
- mention OAuth 'Web application' credentials for the server
- outline adding `http://localhost` as a redirect URI
- explain where to place `client_id.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a9879e71c832a95a64fb9b4360d24