### PR TITLE
Add auth URL validation tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -298,36 +298,38 @@ app.use((err, req, res, _next) => {
     res.status(500).json({ error: 'Internal server error' });
 });
 
-// Setup Google credentials if provided via environment variable
-if (process.env.GOOGLE_CREDENTIALS_JSON) {
-    try {
-        fs.writeFileSync('/tmp/google-credentials.json', process.env.GOOGLE_CREDENTIALS_JSON);
-        process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/google-credentials.json';
-        console.log('Google credentials configured from environment variable');
-    } catch (err) {
-        console.error('Failed to setup Google credentials:', err.message);
+if (require.main === module) {
+    // Setup Google credentials if provided via environment variable
+    if (process.env.GOOGLE_CREDENTIALS_JSON) {
+        try {
+            fs.writeFileSync('/tmp/google-credentials.json', process.env.GOOGLE_CREDENTIALS_JSON);
+            process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/google-credentials.json';
+            console.log('Google credentials configured from environment variable');
+        } catch (err) {
+            console.error('Failed to setup Google credentials:', err.message);
+        }
     }
+
+    // Start server
+    app.listen(port, '0.0.0.0', () => {
+        console.log(`md2slides HTTP server running on port ${port}`);
+        console.log(`Health check: http://localhost:${port}/health`);
+        console.log(`API documentation: http://localhost:${port}/`);
+    });
+
+    // Graceful shutdown
+    process.on('SIGTERM', () => {
+        console.log('Received SIGTERM, shutting down gracefully');
+        // eslint-disable-next-line n/no-process-exit
+        process.exit(0);
+    });
+
+    process.on('SIGINT', () => {
+        console.log('Received SIGINT, shutting down gracefully');
+        // eslint-disable-next-line n/no-process-exit
+        process.exit(0);
+    });
 }
 
-// Start server
-app.listen(port, '0.0.0.0', () => {
-    console.log(`md2slides HTTP server running on port ${port}`);
-    console.log(`Health check: http://localhost:${port}/health`);
-    console.log(`API documentation: http://localhost:${port}/`);
-});
-
-// Graceful shutdown
-process.on('SIGTERM', () => {
-    console.log('Received SIGTERM, shutting down gracefully');
-    // eslint-disable-next-line n/no-process-exit
-    process.exit(0);
-});
-
-process.on('SIGINT', () => {
-    console.log('Received SIGINT, shutting down gracefully');
-    // eslint-disable-next-line n/no-process-exit
-    process.exit(0);
-});
-
-module.exports = app;
+module.exports = { app, generateAuthUrl };
 

--- a/test/cli_authorize.spec.ts
+++ b/test/cli_authorize.spec.ts
@@ -1,0 +1,42 @@
+import mockfs from 'mock-fs';
+import {expect} from 'chai';
+
+const ORIGINAL_HOME = process.env.HOME;
+
+function loadCli() {
+  delete require.cache[require.resolve('../bin/md2gslides.js')];
+  return require('../bin/md2gslides.js');
+}
+
+describe('authorizeUser', () => {
+  afterEach(() => {
+    mockfs.restore();
+    delete require.cache[require.resolve('../bin/md2gslides.js')];
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+  });
+
+  it('throws when client_id.json is missing', () => {
+    process.env.HOME = '/tmp/cli-missing';
+    const {authorizeUser} = loadCli();
+    mockfs({});
+    expect(() => authorizeUser()).to.throw(/OAuth client file not found/);
+  });
+
+  it('throws when client_id.json is malformed', () => {
+    process.env.HOME = '/tmp/cli-malformed';
+    const {authorizeUser} = loadCli();
+    mockfs({
+      '/tmp/cli-malformed/.md2googleslides/client_id.json': 'bad-json'
+    });
+    expect(() => authorizeUser()).to.throw(/Unexpected token/);
+  });
+
+  it('throws when client_id.json lacks client_id or client_secret', () => {
+    process.env.HOME = '/tmp/cli-lack';
+    const {authorizeUser} = loadCli();
+    mockfs({
+      '/tmp/cli-lack/.md2googleslides/client_id.json': JSON.stringify({installed: {client_id: 'abc'}})
+    });
+    expect(() => authorizeUser()).to.throw(/client_id or client_secret/);
+  });
+});

--- a/test/server_auth_url.spec.ts
+++ b/test/server_auth_url.spec.ts
@@ -1,0 +1,45 @@
+import mockfs from 'mock-fs';
+import {expect} from 'chai';
+
+const ORIGINAL_HOME = process.env.HOME;
+
+function loadServer() {
+  delete require.cache[require.resolve('../server')];
+  return require('../server');
+}
+
+describe('generateAuthUrl', () => {
+  afterEach(() => {
+    mockfs.restore();
+    delete require.cache[require.resolve('../server')];
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+  });
+
+  it('returns null when client_id.json is missing', () => {
+    process.env.HOME = '/tmp/testhome-missing';
+    const {generateAuthUrl} = loadServer();
+    mockfs({});
+    const url = generateAuthUrl('user@example.com');
+    expect(url).to.be.null;
+  });
+
+  it('returns null when client_id.json is malformed', () => {
+    process.env.HOME = '/tmp/testhome-malformed';
+    const {generateAuthUrl} = loadServer();
+    mockfs({
+      '/tmp/testhome-malformed/.md2googleslides/client_id.json': 'not-json'
+    });
+    const url = generateAuthUrl('user@example.com');
+    expect(url).to.be.null;
+  });
+
+  it('returns null when client_id.json lacks client_id or client_secret', () => {
+    process.env.HOME = '/tmp/testhome-lack';
+    const {generateAuthUrl} = loadServer();
+    mockfs({
+      '/tmp/testhome-lack/.md2googleslides/client_id.json': JSON.stringify({installed: {client_id: 'abc'}})
+    });
+    const url = generateAuthUrl('user@example.com');
+    expect(url).to.be.null;
+  });
+});


### PR DESCRIPTION
## Summary
- expose `generateAuthUrl` and `authorizeUser` for testing
- avoid starting server/CLI during require
- add tests for auth URL generation edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a987cb6e0832a8c990084053d58b8