### PR TITLE
Add discover presentation endpoint

### DIFF
--- a/HTTP_SERVER.md
+++ b/HTTP_SERVER.md
@@ -40,10 +40,17 @@ Content-Type: multipart/form-data
 # Form data with 'markdown' file field
 ```
 
+### Discover Presentation
+```bash
+GET /discover?id=<presentationId>&user=<email>
+```
+Returns metadata about the presentation and inserts md2slides markers if missing.
+
 ### Other Endpoints
 - `GET /` - API documentation
 - `GET /version` - Get md2gslides version
 - `GET /help` - Get CLI help
+- `GET /discover?id=<ID>&user=<email>` - Discover slides and layouts
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- expose a new `/discover` endpoint in the HTTP API
- return layouts and slide info after inserting md2slides markers when needed
- document the new endpoint in `HTTP_SERVER.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ca32a69b0832a90a23fe84cef41c6