### PR TITLE
Fix OAuth callback URL

### DIFF
--- a/DEPLOYMENT_OAUTH_FIX.md
+++ b/DEPLOYMENT_OAUTH_FIX.md
@@ -64,7 +64,7 @@ curl -X POST http://localhost:3000/convert-text \
 ### 3. Tester le callback OAuth
 ```bash
 # Utiliser le nouveau code d'autorisation
-curl "http://localhost:3000/oauth/callback?state=contact@groupe-pmvb.com&code=NOUVEAU_CODE&scope=..."
+curl "https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback?state=contact@groupe-pmvb.com&code=NOUVEAU_CODE&scope=..."
 ```
 
 ### 4. Vérifier le stockage des tokens
@@ -101,7 +101,7 @@ docker exec md2slides ls -la /home/md2gslides/
 
 Assurez-vous que dans Google Cloud Console :
 - **Type de client** : Application Web
-- **URI de redirection autorisée** : `http://localhost:3000/oauth/callback`
+- **URI de redirection autorisée** : `https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback`
 - **Origines JavaScript autorisées** (optionnel) : `http://localhost:3000`
 
 Le problème "read-only file system" est maintenant résolu ! 🎯

--- a/OAUTH_CONFIG.md
+++ b/OAUTH_CONFIG.md
@@ -10,7 +10,7 @@ Ce document explique comment configurer correctement OAuth 2.0 pour md2googlesli
 - **Type de client ambigu** : Configuration entre app installée et web app
 
 ### Après (Configuration correcte)
-- **Redirect URI complète** : `http://localhost:3000/oauth/callback`
+- **Redirect URI complète** : `https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback`
 - **Endpoint callback fonctionnel** : `GET /oauth/callback`
 - **Configuration web app** : Adaptée aux applications web
 
@@ -24,7 +24,7 @@ Ce document explique comment configurer correctement OAuth 2.0 pour md2googlesli
 Ajoutez dans Google Cloud Console → APIs & Services → Credentials → Votre Client OAuth 2.0 :
 
 ```
-http://localhost:3000/oauth/callback
+https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback
 ```
 
 ### 3. Origines JavaScript autorisées (optionnel)
@@ -54,7 +54,7 @@ Maintenant inclut l'URI de redirection OAuth pour vérification :
 ```json
 {
   "status": "healthy",
-  "oauth_redirect_uri": "http://localhost:3000/oauth/callback"
+  "oauth_redirect_uri": "https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback"
 }
 ```
 
@@ -80,7 +80,7 @@ Si l'utilisateur n'est pas autorisé, réponse :
 L'utilisateur visite `auth_url` et autorise l'application.
 
 ### 3. Callback automatique
-Google redirige vers `http://localhost:3000/oauth/callback` avec le code d'autorisation.
+Google redirige vers `https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback` avec le code d'autorisation.
 
 ### 4. Stockage des tokens
 L'application échange le code contre des tokens et les stocke pour utilisation future.
@@ -92,7 +92,7 @@ Les appels suivants utilisent les tokens stockés automatiquement.
 
 ### ✅ Redirect URI complète avec port
 ```javascript
-const REDIRECT_URI = `http://localhost:${port}/oauth/callback`;
+const REDIRECT_URI = `https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback`;
 ```
 
 ### ✅ Gestion d'état (state parameter)

--- a/server.js
+++ b/server.js
@@ -19,7 +19,8 @@ const CREDENTIALS_PATH = path.join(HOME, '.md2googleslides', 'credentials.json')
 const CLIENT_ID_PATH = path.join(HOME, '.md2googleslides', 'client_id.json');
 
 // OAuth 2.0 redirect URI for web application
-const REDIRECT_URI = `http://localhost:${port}/oauth/callback`;
+// Updated to use the public domain instead of localhost
+const REDIRECT_URI = 'https://n8n-ivayh-u36210.vm.elestio.app/oauth/callback';
 
 function getStoredToken(user) {
     try {


### PR DESCRIPTION
## Summary
- update redirect URL constant in `server.js`
- document new OAuth callback URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cf3e57c48832a8c9848dd986f5b72