### PR TITLE
Fix OAuth token persistence

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -124,6 +124,9 @@ export default class UserAuthorizer {
     const code = await this.prompt(authUrl);
     const tokenResponse = await oauth2Client.getToken(code);
     oauth2Client.setCredentials(tokenResponse.tokens);
+    // Persist credentials including refresh token for future runs
+    this.db.data[user] = tokenResponse.tokens;
+    this.db.write();
     return oauth2Client;
   }
 


### PR DESCRIPTION
## Summary
- persist credentials after initial authorization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d338d1124832a928c8bf8a940f5a3