### PR TITLE
Add layout and placeholder metadata to discovery

### DIFF
--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -25,6 +25,7 @@ chai.use(chaiAsPromised);
 function stubTokenRequest(): void {
   nock('https://oauth2.googleapis.com').post('/token').reply(200, {
     access_token: 'new_token',
+    refresh_token: 'refresh',
     expires_in: 3920,
     token_type: 'Bearer',
   });

--- a/test/deck_import.spec.ts
+++ b/test/deck_import.spec.ts
@@ -31,6 +31,7 @@ describe('ensureMarkers', () => {
     const info = await ensureMarkers(creds(), '12345');
     expect(info.slides).to.have.length(3);
     expect(info.layouts).to.be.an('array');
+    expect(info.slides[0]).to.have.property('placeholders');
     expect(nock.isDone()).to.be.true;
   });
 });


### PR DESCRIPTION
## Summary
- enhance discovery with layout and placeholder info
- fix token stub to return refresh token
- assert placeholders returned in discovery data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f8095fbfc832a9ae1df4f18fb3e36