### PR TITLE
Add bullet symbol & theme color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Some text with *emphasis* and an image:
 ![](https://picsum.photos/800/600)
 ```
 
+### Lists and colors
+
+Bullet lists can start with `-`, `•`, `→` or `★` and numbered lists use the usual `1.` notation. Indent items to create nested lists.
+
+Text color can be set using inline CSS. If the color value isn't a standard CSS color, it is interpreted as a theme color name from your presentation template:
+
+```markdown
+<span style="color: ACCENT1">Themed text</span>
+```
+
 ## Development
 
 Requires Node.js 18+.

--- a/examples/example.md
+++ b/examples/example.md
@@ -144,6 +144,24 @@ Dogs   | 75 million
 Birds  | 16 million
 
 ---
+# Lists
+
+• Premier point
+→ Deuxième point
+★ Troisième point
+
+1. Premier élément
+2. Deuxième élément
+3. Troisième élément
+
+- Point principal 1
+  - Sous-point 1.1
+  - Sous-point 1.2
+- Point principal 2
+  - Sous-point 2.1
+  - Sous-point 2.2
+
+---
 # Some inline HTML and CSS is supported
 
 Use <span style="color:red">span</span> to color text.

--- a/src/parser/css.ts
+++ b/src/parser/css.ts
@@ -30,18 +30,23 @@ export interface Stylesheet {
   [key: string]: CssRule;
 }
 
-function parseColorString(hexString: string): Color | undefined {
-  const c = parseColor(hexString);
-  if (!c.rgba) {
-    return;
+function parseColorString(str: string): Color | undefined {
+  const c = parseColor(str);
+  if (c.rgba) {
+    return {
+      opaqueColor: {
+        rgbColor: {
+          red: c.rgba[0] / 255,
+          green: c.rgba[1] / 255,
+          blue: c.rgba[2] / 255,
+        },
+      },
+    };
   }
+  // If parse-color can't handle the value, assume it's a theme color name
   return {
     opaqueColor: {
-      rgbColor: {
-        red: c.rgba[0] / 255,
-        green: c.rgba[1] / 255,
-        blue: c.rgba[2] / 255,
-      },
+      themeColor: str.toUpperCase(),
     },
   };
 }
@@ -69,6 +74,12 @@ export function updateStyleDefinition(
     switch (key) {
       case 'color':
         style.foregroundColor = parseColorString(value);
+        break;
+      case 'themeColor':
+      case 'theme-color':
+        style.foregroundColor = {
+          opaqueColor: {themeColor: (value as string).toUpperCase()},
+        };
         break;
       case 'backgroundColor':
         style.backgroundColor = parseColorString(value);

--- a/src/parser/extract_slides.ts
+++ b/src/parser/extract_slides.ts
@@ -32,6 +32,7 @@ function preprocessMarkdown(markdown: string): string {
   const out: string[] = [];
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    // Support slide separators
     const match = line.match(/^---\s*(\{.*\})?\s*$/);
     if (match) {
       if (out.length > 0 && out[out.length - 1].trim() !== '') {
@@ -41,6 +42,12 @@ function preprocessMarkdown(markdown: string): string {
       if (match[1]) {
         out.push(match[1].trim());
       }
+      continue;
+    }
+    // Convert non standard bullet markers to markdown compatible ones
+    const bullet = line.match(/^(\s*)([\u2022\u2192\u2605])\s+/); // • → ★
+    if (bullet) {
+      out.push(`${bullet[1]}- ${line.slice(bullet[0].length)}`);
       continue;
     }
     out.push(line);


### PR DESCRIPTION
## Summary
- handle special bullet markers (• → ★)
- allow theme color names in CSS styles
- document lists and color support
- show list examples in sample markdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f83a29cc832a8a3cf3c41e979e84