### PR TITLE
Add slide element metadata in discover service

### DIFF
--- a/docs/DISCOVER_SERVICE.md
+++ b/docs/DISCOVER_SERVICE.md
@@ -50,12 +50,24 @@ interface SlideMeta {
   title?: string;
   index: number;
   placeholders: PlaceholderMeta[];
+  elements: ElementMeta[];
 }
 
 interface PlaceholderMeta {
   objectId: string;
   type?: string;
   text?: string;
+  transform?: AffineTransform;
+  size?: Size;
+}
+
+interface ElementMeta {
+  objectId: string;
+  elementType: string;
+  placeholderType?: string;
+  text?: string;
+  imageUrl?: string;
+  videoUrl?: string;
   transform?: AffineTransform;
   size?: Size;
 }
@@ -133,6 +145,14 @@ console.log('Nombre de slides:', metadata.presentation.slides.length);
           {
             "objectId": "title_obj_1",
             "type": "TITLE",
+            "text": "Ma Présentation"
+          }
+        ],
+        "elements": [
+          {
+            "objectId": "title_obj_1",
+            "elementType": "shape",
+            "placeholderType": "TITLE",
             "text": "Ma Présentation"
           }
         ]

--- a/test/deck_import.spec.ts
+++ b/test/deck_import.spec.ts
@@ -32,6 +32,7 @@ describe('ensureMarkers', () => {
     expect(info.slides).to.have.length(3);
     expect(info.layouts).to.be.an('array');
     expect(info.slides[0]).to.have.property('placeholders');
+    expect(info.slides[0]).to.have.property('elements');
     expect(nock.isDone()).to.be.true;
   });
 });


### PR DESCRIPTION
## Summary
- expand discover's slide metadata with new `ElementMeta`
- return `elements` for each slide in discover
- document new structure in DISCOVER_SERVICE.md
- test for new `elements` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888fda26d20832aa676b3c21c34fee3