### PR TITLE
Improve .column parsing

### DIFF
--- a/src/parser/extract_slides.ts
+++ b/src/parser/extract_slides.ts
@@ -50,6 +50,19 @@ function preprocessMarkdown(markdown: string): string {
       out.push(`${bullet[1]}- ${line.slice(bullet[0].length)}`);
       continue;
     }
+    // Handle column marker followed by text on the same line
+    const columnMatch = line.match(/^(\s*)\{\.column\}\s*(.*)$/);
+    if (columnMatch) {
+      if (out.length > 0 && out[out.length - 1].trim() !== '') {
+        out.push('');
+      }
+      out.push(`${columnMatch[1]}{.column}`);
+      if (columnMatch[2]) {
+        out.push('');
+        out.push(`${columnMatch[1]}${columnMatch[2]}`);
+      }
+      continue;
+    }
     out.push(line);
   }
   return out.join('\n');


### PR DESCRIPTION
## Summary
- support `{.column}` markers with text on the same line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890498104c832abb9c36035ab9cf65