### PR TITLE
Add inline column marker support

### DIFF
--- a/examples/example.md
+++ b/examples/example.md
@@ -66,6 +66,11 @@ This is the *left* column
 ![](https://picsum.photos/g/1600/900)
 
 ---
+# Inline column markers
+
+This is the left {.column} and this is the right
+
+---
 
 # Slides can have background images
 

--- a/src/parser/extract_slides.ts
+++ b/src/parser/extract_slides.ts
@@ -50,16 +50,23 @@ function preprocessMarkdown(markdown: string): string {
       out.push(`${bullet[1]}- ${line.slice(bullet[0].length)}`);
       continue;
     }
-    // Handle column marker followed by text on the same line
-    const columnMatch = line.match(/^(\s*)\{\.column\}\s*(.*)$/);
-    if (columnMatch) {
+    // Handle column marker either at the start of the line or inline
+    const inlineIndex = line.indexOf('{.column}');
+    if (inlineIndex !== -1) {
+      const indentMatch = line.match(/^(\s*)/);
+      const indent = indentMatch ? indentMatch[1] : '';
+      const before = line.slice(0, inlineIndex).trimEnd();
+      const after = line.slice(inlineIndex + '{.column}'.length).trimStart();
+      if (before) {
+        out.push(`${indent}${before}`);
+      }
       if (out.length > 0 && out[out.length - 1].trim() !== '') {
         out.push('');
       }
-      out.push(`${columnMatch[1]}{.column}`);
-      if (columnMatch[2]) {
+      out.push(`${indent}{.column}`);
+      if (after) {
         out.push('');
-        out.push(`${columnMatch[1]}${columnMatch[2]}`);
+        out.push(`${indent}${after}`);
       }
       continue;
     }


### PR DESCRIPTION
## Summary
- allow parsing of `{.column}` inline within text
- demonstrate inline column markers in example deck

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_68893fa65b38832aad41944c9df7451d