### PR TITLE
Fix column marker parsing

### DIFF
--- a/src/parser/extract_slides.ts
+++ b/src/parser/extract_slides.ts
@@ -64,8 +64,11 @@ function preprocessMarkdown(markdown: string): string {
         out.push('');
       }
       out.push(`${indent}{.column}`);
+      // Ensure the column marker is treated as its own paragraph. Markdown
+      // parsing requires a blank line after the marker, otherwise the
+      // following text is appended to the previous paragraph.
+      out.push('');
       if (after) {
-        out.push('');
         out.push(`${indent}${after}`);
       }
       continue;


### PR DESCRIPTION
## Summary
- fix column marker parsing in preprocess
- ensure `{.column}` is handled as a separate paragraph

## Testing
- `npm run compile`
- `node - <<'EOF'
const parse=require('./lib/parser/extract_slides').default;
const fs=require('fs');
const markdown=fs.readFileSync('/tmp/test2.md','utf8');
const slides=parse(markdown);
console.log(slides[0].bodies.map(b=>b.text.rawText));
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6889dcf2b774832ab9784efb4776cbb6