### PR TITLE
Add automatic text resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Convert Markdown or HTML files into Google Slides. Run it locally or inside Dock
 - Docker image for reproducible runs
 - Example templates and layouts
 - HTTP service for automation
+- Automatic text resizing to fit placeholders
 
 ## Quick start
 

--- a/src/layout/generic_layout.ts
+++ b/src/layout/generic_layout.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Debug from 'debug';
-import {uuid} from '../utils';
+import {uuid, estimateFontSize, applyFontSize} from '../utils';
 import extend from 'extend';
 // @ts-ignore
 import Layout from 'layout';
@@ -230,8 +230,12 @@ export default class GenericLayout {
       placeholder = pageElements[0];
     }
 
+    const box = this.calculateBoundingBox(placeholder);
+    const size = estimateFontSize(value.rawText, box);
+    const resized = applyFontSize(value, size);
+
     this.appendInsertTextRequests(
-      value,
+      resized,
       {objectId: placeholder.objectId},
       requests
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,38 @@
 // limitations under the License.
 
 import {v1 as uuidV1} from 'uuid';
+import {TextDefinition, FontSize} from './slides';
 
 export function uuid(): string {
   return uuidV1();
+}
+
+export function emuToPoints(emu: number): number {
+  return emu / 12700;
+}
+
+export function estimateFontSize(
+  text: string,
+  box: {width: number; height: number},
+  max = 48,
+  min = 8
+): number {
+  const widthPt = emuToPoints(box.width);
+  const heightPt = emuToPoints(box.height);
+  const lines = Math.max(text.split('\n').length, 1);
+  const longestLine = text
+    .split('\n')
+    .reduce((m, line) => Math.max(m, line.length), 0);
+  const sizeByHeight = heightPt / (lines * 1.2);
+  const sizeByWidth = widthPt / (longestLine * 0.6);
+  const size = Math.min(max, sizeByHeight, sizeByWidth);
+  return size < min ? min : size;
+}
+
+export function applyFontSize(text: TextDefinition, size: number): TextDefinition {
+  const font: FontSize = {magnitude: size, unit: 'PT'};
+  return {
+    ...text,
+    textRuns: text.textRuns.map(run => ({...run, fontSize: font})),
+  };
 }


### PR DESCRIPTION
## Summary
- auto-fit text inside placeholders
- expose helpers for font size estimation
- document new text resizing feature

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_688a001aab30832aa32b28ae851fe013