### PR TITLE
Improve font sizing algorithm

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
     "tmp": "^0.2.3",
     "tmp-promise": "^3.0.3",
     "undici": "^7.11.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "@capsizecss/metrics": "^3.1.0",
+    "opentype.js": "^1.3.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.0",
@@ -85,7 +87,11 @@
     "@babel/preset-typescript": "^7.27.1",
     "@babel/register": "^7.27.1",
     "@types/node": "^24.0.13",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "@types/opentype.js": "^1.3.8",
+    "mocha": "^11.7.1",
+    "chai": "^5.2.1",
+    "ts-node": "^10.9.1"
   },
   "bin": {
     "md2gslides": "bin/md2gslides.js"

--- a/src/font-metrics.ts
+++ b/src/font-metrics.ts
@@ -1,0 +1,19 @@
+import arial from '@capsizecss/metrics/arial';
+import roboto from '@capsizecss/metrics/roboto';
+
+export interface CapsizeMetrics {
+  ascent: number;
+  descent: number;
+  lineGap: number;
+  unitsPerEm: number;
+  xWidthAvg: number;
+}
+
+const METRICS: Record<string, CapsizeMetrics> = {
+  Arial: arial as unknown as CapsizeMetrics,
+  Roboto: roboto as unknown as CapsizeMetrics,
+};
+
+export function getFontMetrics(fontFamily: string): CapsizeMetrics {
+  return METRICS[fontFamily] || METRICS['Arial'];
+}

--- a/src/text-measurement.ts
+++ b/src/text-measurement.ts
@@ -1,0 +1,53 @@
+import {getFontMetrics} from './font-metrics';
+
+export interface MeasuredText {
+  width: number;
+  height: number;
+  lines: number;
+}
+
+function charWidth(charCount: number, fontSize: number, fontFamily: string): number {
+  const metrics = getFontMetrics(fontFamily);
+  const scale = fontSize / metrics.unitsPerEm;
+  const avg = metrics.xWidthAvg;
+  return charCount * avg * scale;
+}
+
+function lineHeight(fontSize: number, fontFamily: string): number {
+  const m = getFontMetrics(fontFamily);
+  const scale = fontSize / m.unitsPerEm;
+  return (m.ascent - m.descent + m.lineGap) * scale;
+}
+
+export function measureWrappedText(
+  text: string,
+  fontSize: number,
+  boxWidth: number,
+  fontFamily = 'Arial'
+): MeasuredText {
+  const paragraphs = text.split('\n');
+  const lh = lineHeight(fontSize, fontFamily);
+  let lines = 0;
+  let maxWidth = 0;
+  for (const p of paragraphs) {
+    if (p.trim() === '') {
+      lines += 1;
+      continue;
+    }
+    const words = p.split(' ');
+    let lineWidth = 0;
+    for (const word of words) {
+      const wordWidth = charWidth(word.length, fontSize, fontFamily) + charWidth(1, fontSize, fontFamily);
+      if (lineWidth + wordWidth > boxWidth && lineWidth > 0) {
+        maxWidth = Math.max(maxWidth, lineWidth);
+        lines += 1;
+        lineWidth = wordWidth;
+      } else {
+        lineWidth += wordWidth;
+      }
+    }
+    maxWidth = Math.max(maxWidth, lineWidth);
+    lines += 1;
+  }
+  return {width: maxWidth, height: lines * lh, lines};
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@
 import {v1 as uuidV1} from 'uuid';
 
 import {TextDefinition, FontSize, StyleDefinition} from './slides';
+import {measureWrappedText} from './text-measurement';
 
 
 export function uuid(): string {
@@ -33,14 +34,23 @@ export function estimateFontSize(
 ): number {
   const widthPt = emuToPoints(box.width);
   const heightPt = emuToPoints(box.height);
-  const lines = Math.max(text.split('\n').length, 1);
-  const longestLine = text
-    .split('\n')
-    .reduce((m, line) => Math.max(m, line.length), 0);
-  const sizeByHeight = heightPt / (lines * 1.2);
-  const sizeByWidth = widthPt / (longestLine * 0.6);
-  const size = Math.min(max, sizeByHeight, sizeByWidth);
-  return size < min ? min : size;
+
+  let low = min;
+  let high = max;
+  let best = min;
+
+  while (high - low > 0.5) {
+    const mid = (low + high) / 2;
+    const {width, height} = measureWrappedText(text, mid, widthPt);
+    if (width <= widthPt && height <= heightPt) {
+      best = mid;
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+
+  return best;
 }
 
 

--- a/test/font-sizing.spec.ts
+++ b/test/font-sizing.spec.ts
@@ -1,0 +1,14 @@
+import {expect} from 'chai';
+import {estimateFontSize, emuToPoints} from '../src/utils';
+import {measureWrappedText} from '../src/text-measurement';
+
+describe('estimateFontSize', () => {
+  it('fits text inside the box', () => {
+    const text = 'hello world '.repeat(20);
+    const box = {width: 5000000, height: 2000000};
+    const size = estimateFontSize(text, box, 48, 8);
+    const {width, height} = measureWrappedText(text, size, emuToPoints(box.width));
+    expect(width).to.be.at.most(emuToPoints(box.width) + 0.01);
+    expect(height).to.be.at.most(emuToPoints(box.height) + 0.01);
+  });
+});


### PR DESCRIPTION
## Summary
- implement wrapped text measurement using capsize metrics
- add font metrics module
- replace font size estimator with binary search using measurement
- add unit test for new logic
- include metrics and opentype as dependencies

## Testing
- `NODE_OPTIONS="--loader ts-node/register" npx mocha "test/**/*.ts"` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_688a0d35f630832ab6dd17525fbfc859