### PR TITLE
Fix TypeScript builds with Node export map resolution

### DIFF
--- a/src/parser/env.ts
+++ b/src/parser/env.ts
@@ -26,7 +26,7 @@ import extend from 'extend';
 import * as _ from 'lodash';
 import {Stylesheet} from './css';
 import assert from 'assert';
-import {Element} from 'parse5/dist/tree-adapters/default';
+import type { DefaultTreeAdapterTypes } from 'parse5';
 
 export class Context {
   public slides: SlideDefinition[] = [];
@@ -39,7 +39,7 @@ export class Context {
   public row: TextDefinition[] = [];
   public table?: TableDefinition;
   public list?: ListDefinition;
-  public inlineHtmlContext?: Element;
+  public inlineHtmlContext?: DefaultTreeAdapterTypes.Element;
   public images: ImageDefinition[] = [];
   public videos: VideoDefinition[] = [];
 

--- a/src/parser/extract_slides.ts
+++ b/src/parser/extract_slides.ts
@@ -16,7 +16,7 @@ import Debug from 'debug';
 import extend from 'extend';
 type Token = any;
 import * as parse5 from 'parse5';
-import {Element} from 'parse5/dist/tree-adapters/default';
+import type { DefaultTreeAdapterTypes } from 'parse5';
 import fileUrl from 'file-url';
 import {SlideDefinition, StyleDefinition} from '../slides';
 import parseMarkdown from './parser';
@@ -176,7 +176,7 @@ inlineTokenRules['html_inline'] = (token, context) => {
     ? parse5.parseFragment(context.inlineHtmlContext as any, token.content)
     : parse5.parseFragment(token.content);
   if (fragment.childNodes && fragment.childNodes.length) {
-    const node = fragment.childNodes[0] as Element;
+    const node = fragment.childNodes[0] as DefaultTreeAdapterTypes.Element;
     const style: StyleDefinition = {};
 
     switch (node.nodeName) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es2018",
     "lib": ["es2018"],
-    "module": "commonjs",
     "rootDir": ".",
     "outDir": "lib",
     "esModuleInterop": true,
@@ -10,7 +9,8 @@
     "noEmit": false,
     "skipLibCheck": true,
     "strict": false,
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary
- enable NodeNext module resolution
- update parse5 element imports for export maps

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_688a16ec7420832a92b2bfd0e67f5b3e