### PR TITLE
Add dynamic font support

### DIFF
--- a/src/font-metrics.ts
+++ b/src/font-metrics.ts
@@ -1,5 +1,7 @@
 import arial from '@capsizecss/metrics/arial';
 import roboto from '@capsizecss/metrics/roboto';
+import {fontFamilyToCamelCase} from '@capsizecss/metrics';
+import {entireMetricsCollection} from '@capsizecss/metrics/entireMetricsCollection';
 
 export interface CapsizeMetrics {
   ascent: number;
@@ -14,6 +16,22 @@ const METRICS: Record<string, CapsizeMetrics> = {
   Roboto: roboto as unknown as CapsizeMetrics,
 };
 
+function loadMetrics(fontFamily: string): CapsizeMetrics | undefined {
+  const key = fontFamilyToCamelCase(fontFamily);
+  const metrics = (entireMetricsCollection as Record<string, any>)[key];
+  if (!metrics) {
+    return undefined;
+  }
+  const {ascent, descent, lineGap, unitsPerEm, xWidthAvg} = metrics;
+  return {ascent, descent, lineGap, unitsPerEm, xWidthAvg};
+}
+
 export function getFontMetrics(fontFamily: string): CapsizeMetrics {
+  if (!METRICS[fontFamily]) {
+    const loaded = loadMetrics(fontFamily);
+    if (loaded) {
+      METRICS[fontFamily] = loaded;
+    }
+  }
   return METRICS[fontFamily] || METRICS['Arial'];
 }

--- a/src/layout/generic_layout.ts
+++ b/src/layout/generic_layout.ts
@@ -231,7 +231,9 @@ export default class GenericLayout {
     }
 
     const box = this.calculateBoundingBox(placeholder);
-    const size = estimateFontSize(value.rawText, box);
+    const firstRun = value.textRuns[0];
+    const fontFamily = firstRun?.fontFamily || 'Arial';
+    const size = estimateFontSize(value.rawText, box, 48, 8, fontFamily);
     const resized = applyFontSize(value, size);
 
     this.appendInsertTextRequests(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,8 @@ export function estimateFontSize(
   text: string,
   box: {width: number; height: number},
   max = 48,
-  min = 8
+  min = 8,
+  fontFamily = 'Arial'
 ): number {
   const widthPt = emuToPoints(box.width);
   const heightPt = emuToPoints(box.height);
@@ -41,7 +42,7 @@ export function estimateFontSize(
 
   while (high - low > 0.5) {
     const mid = (low + high) / 2;
-    const {width, height} = measureWrappedText(text, mid, widthPt);
+    const {width, height} = measureWrappedText(text, mid, widthPt, fontFamily);
     if (width <= widthPt && height <= heightPt) {
       best = mid;
       low = mid;


### PR DESCRIPTION
## Summary
- fetch metrics for any font via `@capsizecss/metrics`
- use detected font family when computing text size

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_688a25533cb8832abc61bbd663f42dc7