### PR TITLE
Fix prepublish script execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "compile": "tsc && babel --extensions '.ts,.js' --source-maps both -d lib/ src/",
-    "prepublish": "npm run compile",
+    "prepublishOnly": "npm run compile",
     "exec": "npm run compile && node bin/md2gslides.js",
     "server": "node server.js",
     "start": "npm run server",


### PR DESCRIPTION
## Summary
- avoid running compile twice during install by using `prepublishOnly`

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_688b6970a7d8832a8bdd26a39f216a68