### PR TITLE
Reduce font size and enable slide text autofit

### DIFF
--- a/src/deck_import.ts
+++ b/src/deck_import.ts
@@ -257,6 +257,16 @@ export async function editSlide(
           insertionIndex: 0,
         },
       });
+      // Ensure text automatically shrinks to fit the shape bounds
+      requests.push({
+        updateShapeProperties: {
+          objectId: u.elementId,
+          shapeProperties: {
+            autofit: {autofitType: 'TEXT_AUTOFIT'},
+          },
+          fields: 'autofit',
+        },
+      });
     }
     if (u.imageUrl) {
       requests.push({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,8 @@ export function applyFontSize(
   base = 18
 ): TextDefinition {
   const currentMax = maxFontSize(text, base);
-  const ratio = targetSize / currentMax;
+  // Apply a 20% reduction to better match rendered sizes in Slides
+  const ratio = (targetSize / currentMax) * 0.8;
 
   const baseRun: StyleDefinition = {
     start: 0,


### PR DESCRIPTION
## Summary
- shrink applied font sizes by 20% to better match rendering on Google Slides
- update `editSlide` to enable automatic text autofit when inserting text

## Testing
- `node --loader ts-node/esm node_modules/mocha/bin/mocha.js test/**/*.spec.ts` *(fails: Error [ERR_REQUIRE_CYCLE_MODULE]: Cannot require() ES Module /workspace/md2googleslides/test/deck_import.spec.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_688b7b0c711c832aab5cc65feea9de1f